### PR TITLE
createing-get-new-memo

### DIFF
--- a/app/assets/stylesheets/memos.scss
+++ b/app/assets/stylesheets/memos.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the memos controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -1,0 +1,28 @@
+class MemosController < ApplicationController
+  def index
+    @memos = Memo.all
+  end
+
+  def show
+  end
+
+  def new
+    @memo = Memo.new
+  end
+
+  def edit
+  end
+
+  def create
+    memo = Memo.new(memo_params)
+    memo.save!
+    redirect_to memos_url, notice: "メモ「#{memo.title}」を保存しました。"
+  end
+
+  private
+
+  def memo_params
+    params.require(:memo).permit(:title, :description)
+  end
+
+end

--- a/app/helpers/memos_helper.rb
+++ b/app/helpers/memos_helper.rb
@@ -1,0 +1,2 @@
+module MemosHelper
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,4 +11,6 @@ html
     .app-title.navbar-expand-md.navbar-light.bg-light
       .navbar-brand Zeromemo
     .container
+      -if flash.notice.present?
+        .alert.alert-success= flash.notice
     = yield

--- a/app/views/memos/edit.html.slim
+++ b/app/views/memos/edit.html.slim
@@ -1,0 +1,2 @@
+h1 Memos#edit
+p Find me in app/views/memos/edit.html.slim

--- a/app/views/memos/index.html.slim
+++ b/app/views/memos/index.html.slim
@@ -1,0 +1,15 @@
+h1 メモ一覧
+
+= link_to '新規登録', new_memo_path, class: 'btn btn-primary'
+
+.mb-3
+table.table.table-hover
+  thead.thead-dark
+    tr
+      th= Memo.human_attribute_name(:タイトル)
+      th= Memo.human_attribute_name(:登録日時)
+  tbody
+    - @memos.each do |memo|
+      tr
+        td= memo.title
+        td= memo.created_at

--- a/app/views/memos/new.html.slim
+++ b/app/views/memos/new.html.slim
@@ -1,0 +1,13 @@
+h1 メモの新規登録
+
+.nav.justify-content-end
+  = link_to 'メモ一覧', memos_path, class: 'nav-link'
+
+= form_with model: @memo, local: true do |f|
+  .form-group
+    =f.label :"タイトル"
+    =f.text_field :title, class: 'form-control', id: 'task_name'
+  .form-group
+    = f.label :"メモ書き"
+    = f.text_area :description, rows: 10, class: 'form-control', id: 'task_description'
+  = f.submit "保存する", class: 'btn btn-primary'

--- a/app/views/memos/show.html.slim
+++ b/app/views/memos/show.html.slim
@@ -1,0 +1,2 @@
+h1 Memos#show
+p Find me in app/views/memos/show.html.slim

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,15 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+  models:
+    memo: メモ
+    attributes:
+    memo:
+      id: ID
+      title: タイトル
+      description: 詳しい説明
+      created_at: 登録時間
+      updated_at: 更新時間
   date:
     abbr_day_names:
     - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  root to: 'memos#index'
+  resources :memos
 end

--- a/test/controllers/memos_controller_test.rb
+++ b/test/controllers/memos_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class MemosControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get memos_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get memos_show_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get memos_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get memos_edit_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
#what
メモの新規投稿機能の実装
メモが保存されたときには、フラッシュメッセージを新規登録時に実装した。
また、メモのタイトルと、登録時間をindexビューに挿入した。
Bootstrapのtable機能と、bt-3を組み合わせて作った。
#why
新規投稿機能の実装は根幹であるため
また、保存されたときにインデックスビューでしっかりと全部のメモが見れるように実装した。