### PR TITLE
add-admin-user-view-full-function

### DIFF
--- a/app/assets/stylesheets/admin/users.scss
+++ b/app/assets/stylesheets/admin/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Admin::Users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,48 @@
+class Admin::UsersController < ApplicationController
+  def new
+    @user = User.new
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def show
+    @user = User.find(params[:id])
+  end
+
+  def index
+    @user = User.all
+  end
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to admin_user_url(@user), notice: "ユーザー「#{@user.name}」を登録しました。"
+    else
+      render :new
+    end
+  end
+
+  def update
+    user = User.find(params[:id])
+    if user.update(user_params)
+      redirect_to admin_users_url, notice: "ユーザー名「#{user.name}」を更新しました。"
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    user = User.find(params[:id])
+    user.destroy
+    redirect_to admin_users_url, notice: "ユーザー名「#{user.name}」を削除しました。"
+  end
+
+
+  private
+  
+  def user_params
+    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+  end
+
+end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
+
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
 end

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -1,0 +1,23 @@
+- if user.errors.present?
+  ul#error_explanation, 
+    - user.errors.full_messages.each.do |message|
+      li = message 
+= form_with model:[:admin, @user], local: true do |f|
+  .form-group
+    =f.label :name, '名前'
+    =f.text_field :name, class: 'form-control'
+  .form-group
+    =f.label :email, 'email'
+    =f.text_field :email, class: 'form-control'
+  .form-check
+    =f.label :adimn, class: 'form-check-label' do
+      =f.check_box :admin, class: 'form-check-input'
+      | 管理者権限
+  .form-group
+    =f.label :password, 'パスワード'
+    =f.password_field :password, class: 'form-control'
+  .form-group
+    =f.label :password_confirmation, 'パスワード（確認）'
+    =f.password_field :password_confirmation, class: 'form-control'
+  =f.submit '登録する', class: 'btn btn-primary mr-5'
+  = link_to 'ユーザー削除', [:admin, @user], method: :delete, data: { confirm: "ユーザー名「#{@user.name}」を削除します。よろしいでしょうか？"}, class: 'btn btn-danger ml-5'

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,0 +1,6 @@
+h1 ユーザーの編集
+
+.nav.justify-content-end
+  = link_to 'ユーザー登録一覧', admin_users_path, class: 'nav-link'
+
+= render partial: 'form', locals: { user: @user }

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,0 +1,27 @@
+h1 ユーザー登録一覧
+
+= link_to '新規登録', new_memo_path, class: 'btn btn-primary'
+
+.mb-3
+table.table.table-hover
+  thead.thead-dark
+    tr
+      th= User.human_attribute_name(:項目)
+      th= User.human_attribute_name(:ユーザー名)
+      th= User.human_attribute_name(:メールアドレス)
+      th= User.human_attribute_name(:管理者)
+      th= User.human_attribute_name(:登録時間)
+      th= User.human_attribute_name(:更新時間)
+      th
+  tbody
+    - @user.each do |user|
+      tr
+        th= User.human_attribute_name(:登録情報)
+        td= link_to user.name, [:admin, user]
+        td= user.email
+        td= user.admin? ? 'あり' : 'なし'
+        td= user.created_at
+        td= user.updated_at
+        td
+          = link_to 'ユーザー登録編集', edit_admin_user_path(user), class: 'btn btn-primary mr-5'
+          = link_to 'ユーザー登録削除',[:admin, user] , method: :delete, data: { confirm: "ユーザー「#{user.name}」を削除します。よろしいでしょうか？"}, class: 'btn btn-danger ml-5'

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,0 +1,7 @@
+h1 ユーザー登録
+
+=form_with model: [:admin, @user], local: true do |f|
+.nav.justify-content-end
+  = link_to 'ユーザー登録一覧', admin_users_path, class: 'nav-link'
+
+= render partial: 'form', locals: { user: @user }

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -1,0 +1,29 @@
+h1 ユーザー登録の詳細
+.nav.justify-content-end
+  = link_to 'ユーザー登録一覧', admin_users_path, class: 'nav-link'
+table.table.table-hover
+  thead.thead-dark
+    tr 
+      th= User.human_attribute_name(:項目)
+      th= User.human_attribute_name(:内容)
+  tbody
+    tr
+      th= User.human_attribute_name(:登録番号)
+      td= @user.id
+    tr
+      th= User.human_attribute_name(:ユーザー名)
+      td= @user.name
+    tr
+      th= User.human_attribute_name(:メールアドレス)
+      td= @user.email
+    tr
+      th= User.human_attribute_name(:管理者)
+      td= @user.admin? ? 'あり' : 'なし'
+    tr
+      th= User.human_attribute_name(:登録日時)
+      td= @user.created_at
+    tr
+      th= User.human_attribute_name(:更新日時)
+      td= @user.updated_at
+= link_to 'ユーザー編集', edit_admin_user_path, class: 'btn btn-primary mr-3'
+= link_to 'ユーザー削除', [:admin, @user], method: :delete, data: { confirm: "ユーザー：「#{@user.name}」を削除します。よろしいでしょうか？"}, class: 'btn btn-danger'

--- a/app/views/memos/show.html.slim
+++ b/app/views/memos/show.html.slim
@@ -14,10 +14,10 @@ table.table.table-hover
       th= Memo.human_attribute_name(:タイトル)
       td= @memo.title
     tr
-      th= Memo.human_attribute_name(:メモ書き（詳細）)
+      th= Memo.human_attribute_name(:メモ（詳細）)
       td= simple_format(h(@memo.description), {}, sanitize: false, wrapper_tag: "div")
     tr
-      th= Memo.human_attribute_name(:保存日時)
+      th= Memo.human_attribute_name(:登録日時)
       td= @memo.created_at
     tr
       th= Memo.human_attribute_name(:更新日時)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,210 +7,222 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
-  models:
-    memo: メモ
-    attributes:
-    memo:
-    id: ID
-    title: タイトル
-    description: メモ書き（詳細）
-    created_at: 登録時間
-    updated_at: 更新時間
-  date:
-    abbr_day_names:
-    - 日
-    - 月
-    - 火
-    - 水
-    - 木
-    - 金
-    - 土
-    abbr_month_names:
-    - 
-    - 1月
-    - 2月
-    - 3月
-    - 4月
-    - 5月
-    - 6月
-    - 7月
-    - 8月
-    - 9月
-    - 10月
-    - 11月
-    - 12月
-    day_names:
-    - 日曜日
-    - 月曜日
-    - 火曜日
-    - 水曜日
-    - 木曜日
-    - 金曜日
-    - 土曜日
-    formats:
-      default: "%Y/%m/%d"
-      long: "%Y年%m月%d日(%a)"
-      short: "%m/%d"
-    month_names:
-    - 
-    - 1月
-    - 2月
-    - 3月
-    - 4月
-    - 5月
-    - 6月
-    - 7月
-    - 8月
-    - 9月
-    - 10月
-    - 11月
-    - 12月
-    order:
-    - :year
-    - :month
-    - :day
-  datetime:
-    distance_in_words:
-      about_x_hours:
-        one: 約1時間
-        other: 約%{count}時間
-      about_x_months:
-        one: 約1ヶ月
-        other: 約%{count}ヶ月
-      about_x_years:
-        one: 約1年
-        other: 約%{count}年
-      almost_x_years:
-        one: 1年弱
-        other: "%{count}年弱"
-      half_a_minute: 30秒前後
-      less_than_x_seconds:
-        one: 1秒以内
-        other: "%{count}秒未満"
-      less_than_x_minutes:
-        one: 1分以内
-        other: "%{count}分未満"
-      over_x_years:
-        one: 1年以上
-        other: "%{count}年以上"
-      x_seconds:
-        one: 1秒
-        other: "%{count}秒"
-      x_minutes:
-        one: 1分
-        other: "%{count}分"
-      x_days:
-        one: 1日
-        other: "%{count}日"
-      x_months:
-        one: 1ヶ月
-        other: "%{count}ヶ月"
-      x_years:
-        one: 1年
-        other: "%{count}年"
-    prompts:
-      second: 秒
-      minute: 分
-      hour: 時
-      day: 日
-      month: 月
-      year: 年
-  errors:
-    format: "%{attribute}%{message}"
-    messages:
-      accepted: を受諾してください
-      blank: を入力してください
-      confirmation: と%{attribute}の入力が一致しません
-      empty: を入力してください
-      equal_to: は%{count}にしてください
-      even: は偶数にしてください
-      exclusion: は予約されています
-      greater_than: は%{count}より大きい値にしてください
-      greater_than_or_equal_to: は%{count}以上の値にしてください
-      inclusion: は一覧にありません
-      invalid: は不正な値です
-      less_than: は%{count}より小さい値にしてください
-      less_than_or_equal_to: は%{count}以下の値にしてください
-      model_invalid: 'バリデーションに失敗しました: %{errors}'
-      not_a_number: は数値で入力してください
-      not_an_integer: は整数で入力してください
-      odd: は奇数にしてください
-      other_than: は%{count}以外の値にしてください
-      present: は入力しないでください
-      required: を入力してください
-      taken: はすでに存在します
-      too_long: は%{count}文字以内で入力してください
-      too_short: は%{count}文字以上で入力してください
-      wrong_length: は%{count}文字で入力してください
-    template:
-      body: 次の項目を確認してください
-      header:
-        one: "%{model}にエラーが発生しました"
-        other: "%{model}に%{count}個のエラーが発生しました"
-  helpers:
-    select:
-      prompt: 選択してください
-    submit:
-      create: 登録する
-      submit: 保存する
-      update: 更新する
-  number:
-    currency:
+  attributes:
+    # memo:
+    #   memo:　メモ
+    #   id: ID
+    #   title: タイトル
+    #   description: メモ書き（詳細）
+    #   created_at: 登録時間
+    #   updated_at: 更新時間
+    #   list: 項目
+    #   contents: 内容
+    # user:
+    #   name: 名前
+    #   email: メールアドレス
+    #   admin: 管理者権限
+    #   password: パスワード
+    #   password_confirmation: パスワード（確認）
+    #   created_at: 登録日時
+    #   updated_at: 更新日時
+    #   list: 項目
+    #   contents: 内容
+    date:
+      abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+      abbr_month_names:
+      - 
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+      day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+      formats:
+        default: "%Y/%m/%d"
+        long: "%Y年%m月%d日(%a)"
+        short: "%m/%d"
+      month_names:
+      - 
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+      order:
+      - :year
+      - :month
+      - :day
+    datetime:
+      distance_in_words:
+        about_x_hours:
+          one: 約1時間
+          other: 約%{count}時間
+        about_x_months:
+          one: 約1ヶ月
+          other: 約%{count}ヶ月
+        about_x_years:
+          one: 約1年
+          other: 約%{count}年
+        almost_x_years:
+          one: 1年弱
+          other: "%{count}年弱"
+        half_a_minute: 30秒前後
+        less_than_x_seconds:
+          one: 1秒以内
+          other: "%{count}秒未満"
+        less_than_x_minutes:
+          one: 1分以内
+          other: "%{count}分未満"
+        over_x_years:
+          one: 1年以上
+          other: "%{count}年以上"
+        x_seconds:
+          one: 1秒
+          other: "%{count}秒"
+        x_minutes:
+          one: 1分
+          other: "%{count}分"
+        x_days:
+          one: 1日
+          other: "%{count}日"
+        x_months:
+          one: 1ヶ月
+          other: "%{count}ヶ月"
+        x_years:
+          one: 1年
+          other: "%{count}年"
+      prompts:
+        second: 秒
+        minute: 分
+        hour: 時
+        day: 日
+        month: 月
+        year: 年
+    errors:
+      format: "%{attribute}%{message}"
+      messages:
+        accepted: を受諾してください
+        blank: を入力してください
+        confirmation: と%{attribute}の入力が一致しません
+        empty: を入力してください
+        equal_to: は%{count}にしてください
+        even: は偶数にしてください
+        exclusion: は予約されています
+        greater_than: は%{count}より大きい値にしてください
+        greater_than_or_equal_to: は%{count}以上の値にしてください
+        inclusion: は一覧にありません
+        invalid: は不正な値です
+        less_than: は%{count}より小さい値にしてください
+        less_than_or_equal_to: は%{count}以下の値にしてください
+        model_invalid: 'バリデーションに失敗しました: %{errors}'
+        not_a_number: は数値で入力してください
+        not_an_integer: は整数で入力してください
+        odd: は奇数にしてください
+        other_than: は%{count}以外の値にしてください
+        present: は入力しないでください
+        required: を入力してください
+        taken: はすでに存在します
+        too_long: は%{count}文字以内で入力してください
+        too_short: は%{count}文字以上で入力してください
+        wrong_length: は%{count}文字で入力してください
+      template:
+        body: 次の項目を確認してください
+        header:
+          one: "%{model}にエラーが発生しました"
+          other: "%{model}に%{count}個のエラーが発生しました"
+    helpers:
+      select:
+        prompt: 選択してください
+      submit:
+        create: 登録する
+        submit: 保存する
+        update: 更新する
+    number:
+      currency:
+        format:
+          delimiter: ","
+          format: "%n%u"
+          precision: 0
+          separator: "."
+          significant: false
+          strip_insignificant_zeros: false
+          unit: 円
       format:
         delimiter: ","
-        format: "%n%u"
-        precision: 0
+        precision: 3
         separator: "."
         significant: false
         strip_insignificant_zeros: false
-        unit: 円
-    format:
-      delimiter: ","
-      precision: 3
-      separator: "."
-      significant: false
-      strip_insignificant_zeros: false
-    human:
-      decimal_units:
-        format: "%n %u"
-        units:
-          billion: 十億
-          million: 百万
-          quadrillion: 千兆
-          thousand: 千
-          trillion: 兆
-          unit: ''
-      format:
-        delimiter: ''
-        precision: 3
-        significant: true
-        strip_insignificant_zeros: true
-      storage_units:
-        format: "%n%u"
-        units:
-          byte: バイト
-          eb: EB
-          gb: GB
-          kb: KB
-          mb: MB
-          pb: PB
-          tb: TB
-    percentage:
-      format:
-        delimiter: ''
-        format: "%n%"
-    precision:
-      format:
-        delimiter: ''
-  support:
-    array:
-      last_word_connector: "、"
-      two_words_connector: "、"
-      words_connector: "、"
-  time:
-    am: 午前
-    formats:
-      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
-      long: "%Y/%m/%d %H:%M"
-      short: "%m/%d %H:%M"
-    pm: 午後
+      human:
+        decimal_units:
+          format: "%n %u"
+          units:
+            billion: 十億
+            million: 百万
+            quadrillion: 千兆
+            thousand: 千
+            trillion: 兆
+            unit: ''
+        format:
+          delimiter: ''
+          precision: 3
+          significant: true
+          strip_insignificant_zeros: true
+        storage_units:
+          format: "%n%u"
+          units:
+            byte: バイト
+            eb: EB
+            gb: GB
+            kb: KB
+            mb: MB
+            pb: PB
+            tb: TB
+      percentage:
+        format:
+          delimiter: ''
+          format: "%n%"
+      precision:
+        format:
+          delimiter: ''
+    support:
+      array:
+        last_word_connector: "、"
+        two_words_connector: "、"
+        words_connector: "、"
+    time:
+      am: 午前
+      formats:
+        default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+        long: "%Y/%m/%d %H:%M"
+        short: "%m/%d %H:%M"
+      pm: 午後
+  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :users
+  end
   root to: 'memos#index'
   resources :memos
 end

--- a/db/migrate/20200728050354_add_admin_to_users.rb
+++ b/db/migrate/20200728050354_add_admin_to_users.rb
@@ -1,4 +1,5 @@
 class AddAdminToUsers < ActiveRecord::Migration[6.0]
   def change
+    add_column :users, :admin, :boolean, default: false, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_032253) do
+ActiveRecord::Schema.define(version: 2020_07_28_050354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2020_07_28_032253) do
     t.string "password_digest", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get admin_users_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get admin_users_edit_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get admin_users_show_url
+    assert_response :success
+  end
+
+  test "should get index" do
+    get admin_users_index_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
#what
ユーザー登録画面、編集、一覧、削除（フラッシュメッセージ）、更新（フラッシュメッセージ）、のviewを完成させた。
また、管理者用にadminを設定した。
#why
ユーザー機能の追加でどの人のメモや、自分用のメモを作成することが可能になる。
また、admin を取り入れることで、管理者を作り、編集機能などを後ほど制限し、セキュリティー向上につなげるため。