### PR TITLE
add-confirm-screen-add-back-btn

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -16,9 +16,18 @@ class MemosController < ApplicationController
   end
 
   def create
-    memo = Memo.new(memo_params.merge(user_id: current_user.id))
-    memo.save!
-    redirect_to memos_url, success: "メモ：タイトル「#{memo.title}」を保存しました。"
+    @memo = current_user.memos.new(memo_params)
+    
+    if params[:back].present?
+      render :new
+      return
+    end
+    
+    if @memo.save
+      redirect_to @memo, success: "メモ：タイトル「#{@memo.title}」を保存しました。"
+    else  
+      render :new
+    end
   end
 
   def update
@@ -29,6 +38,10 @@ class MemosController < ApplicationController
   def destroy
     @memo.destroy
     redirect_to memos_url, success: "メモ：タイトル「#{@memo.title}」を削除しました。"
+  end
+  def confirm_new
+    @memo = current_user.memos.new(memo_params)
+    render :new unless @memo.valid?
   end
   private
 

--- a/app/views/memos/_form.html.slim
+++ b/app/views/memos/_form.html.slim
@@ -3,7 +3,7 @@
     =f.label :"タイトル"
     =f.text_field :title, class: 'form-control', id: 'memo_title', placeholder: '⚠️コロンマーク（,）は使えません'
   .form-group
-    = f.label :"メモ書き"
+    = f.label :"メモ書き欄"
     = f.text_area :description, rows: 10, class: 'form-control', id: 'task_description'
     = f.submit "保存する", class: 'btn btn-primary mr-5'
     = link_to 'メモ削除', @memo, method: :delete, data: { confirm: "メモ：タイトル「#{@memo.title}」を削除します。よろしいでしょうか？"}, class: 'btn btn-danger ml-5'

--- a/app/views/memos/confirm_new.html.slim
+++ b/app/views/memos/confirm_new.html.slim
@@ -1,0 +1,19 @@
+h1 保存内容の確認
+
+= form_with model: @memo, local: true do |f|
+  table.table.table-hover
+    thead.thead-dark
+      tr 
+        th= Memo.human_attribute_name(:項目)
+        th= Memo.human_attribute_name(:内容)
+      tbody
+      tr
+        th= Memo.human_attribute_name(:タイトル)
+        td= @memo.title
+        = f.hidden_field :title
+      tr
+        th= Memo.human_attribute_name(:メモ欄)
+        td= auto_link(simple_format(h(@memo.description), {}, sanitize: false, wrapper_tag: "div"))
+        = f.hidden_field :description
+  = f.submit '戻る', name: 'back', class: 'btn btn-secondary mr-3'
+  = f.submit '保存する', class: 'btn btn-primary'

--- a/app/views/memos/new.html.slim
+++ b/app/views/memos/new.html.slim
@@ -3,4 +3,16 @@ h1 メモの新規登録
 .nav.justify-content-end
   = link_to 'メモ一覧', memos_path, class: 'nav-link'
 
-= render partial: 'form', locals: { memo: @memo }
+- if @memo.errors.present?
+  ul#error_explanation, 
+    - @memo.errors.full_messages.each.do |message|
+      li = message
+= form_with model: @memo, local: true, url: confirm_new_memo_path do |f|
+  .form-group
+    .form-group
+    =f.label :"タイトル"
+    =f.text_field :title, class: 'form-control', id: 'memo_title', placeholder: '⚠️コロンマーク（,）は使えません'
+  .form-group
+    = f.label :"メモ書き欄"
+    = f.text_area :description, rows: 10, class: 'form-control', id: 'task_description'
+  =f.submit '確認', class: 'btn btn-primary'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,8 @@ Rails.application.routes.draw do
     resources :users
   end
   root to: 'memos#index'
+  resources :memos do 
+    post :confirm, action: :confirm_new, on: :new
+  end
   resources :memos
 end


### PR DESCRIPTION
#what
新規メッセージを作った際に確認画面を挿入し、
時間内に記入できないための画面を作った。

#why
今後、タイマーを入れ設定して自動確認画面まで飛ぶようにするため、
書きれない場合は、一旦戻れるようにするためのもの。